### PR TITLE
Definir o idioma inglês caso o install.sql foi executado primeiro

### DIFF
--- a/install.php
+++ b/install.php
@@ -16,6 +16,7 @@ if ($iLang) {
   $oc_language['locale']     = 'pt_BR.UTF-8,pt_BR,pt-br,pt_br,portuguese';
   $oc_language['sort_order'] = 1;
   $oc_language['status']     = 1;
+  $this->config->set('config_language_id', 1);
   $this->model_localisation_language->addLanguage($oc_language);
 }
 


### PR DESCRIPTION
Ao realizar a instalação da tradução no OpenCart 2.3.0.2, percebi o conteúdo demonstrativo, não era mais visível. E ao ver a execução do código, vi que era executado o install.sql primeiro do que o install.php, o qual era definido o idioma português na configuração da loja. Então, quando executava o install.php, na sequência, o método addLanguage do model catalog/model/localisation/language, ele busca o idioma padrão, para pegar as publicações, e como estava em pt-br não encontrava nada, e com isso ao atualizar, ocultava os produtos, status, etc.

Apenas defini, antes de chamar o método addLanguage, o valor para config_language_id, como 1, e com isso o conteúdo era copiado, e era exibido quando atualizava já em português. 
